### PR TITLE
MesonIR: Don't use spaces in tablename for M8SProW

### DIFF
--- a/MesonIR/MeCOOL M8S Pro W/M8SProW
+++ b/MesonIR/MeCOOL M8S Pro W/M8SProW
@@ -1,4 +1,4 @@
-# table M8S Pro W, type: NEC
+# table M8SProW, type: NEC
 0x59 KEY_POWER
 0x08 KEY_PREVIOUSSONG
 0x0b KEY_NEXTSONG


### PR DESCRIPTION
This causes ir-keytable to segfault in CoreElec 19.4